### PR TITLE
Fixed incorrect text property

### DIFF
--- a/erc-colorize.el
+++ b/erc-colorize.el
@@ -128,7 +128,7 @@ message coming from a user."
     (when match-face
       (erc-put-text-property
        (point-min) (point-max)
-       'font-lock-face match-face))))
+       'face match-face))))
 
 
 (provide 'erc-colorize)


### PR DESCRIPTION
This was completely breaking erc-colorize for me (Emacs 24.3.1 on Gnu/Linux)
